### PR TITLE
Prevent host sleep while daemon is running

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,10 @@ Supports multiple daemons on different PCs listening to different queues. The de
 - `service/` — C# Windows service (.NET 8) for running the daemon as a service
 - `tools/` — PowerShell helper scripts
 
+## Pull Request Reviews
+
+- Never approve a PR that has active (unresolved) review comments. All comments must be resolved before approving.
+
 ## Conventions
 
 - Use `uv` for all Python packaging (never `pip`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,10 +57,6 @@ Supports multiple daemons on different PCs listening to different queues. The de
 - `service/` — C# Windows service (.NET 8) for running the daemon as a service
 - `tools/` — PowerShell helper scripts
 
-## Pull Request Reviews
-
-- Never approve a PR that has active (unresolved) review comments. All comments must be resolved before approving.
-
 ## Conventions
 
 - Use `uv` for all Python packaging (never `pip`).

--- a/src/agentinbox/daemon.py
+++ b/src/agentinbox/daemon.py
@@ -28,6 +28,7 @@ from .executors.copilot import CopilotExecutor
 from .executors.command import CommandExecutor
 from .executors.python_script import PythonScriptExecutor
 from .inbox import get_all_directives
+from .keep_awake import prevent_sleep, allow_sleep
 from .notify import post as groupme_post
 from . import task_tracker
 
@@ -196,6 +197,8 @@ def run_daemon(config: Config) -> None:
         else None
     )
 
+    awake = prevent_sleep()
+
     print(f"Agent Inbox daemon started")
     print(f"  Agent: {config.agent_name}")
     print(f"  Queue: {config.resolved_queue_name}")
@@ -205,6 +208,7 @@ def run_daemon(config: Config) -> None:
     print(f"  Working dir: {Path(config.working_directory).resolve()}")
     print(f"  Interval: {config.poll_interval}s")
     print(f"  Log dir: {log_dir}")
+    print(f"  Sleep prevention: {'active' if awake else 'unavailable'}")
     if startup_warning:
         print(f"  {startup_warning}")
     print()
@@ -216,6 +220,7 @@ def run_daemon(config: Config) -> None:
         "executor": executor.name(),
         "copilot": executor.resolved_path if isinstance(executor, CopilotExecutor) else None,
         "interval": config.poll_interval,
+        "sleep_prevention": awake,
     })
     if startup_warning:
         _log_entry(log_dir, {
@@ -260,5 +265,6 @@ def run_daemon(config: Config) -> None:
             time.sleep(config.poll_interval)
 
     except KeyboardInterrupt:
+        allow_sleep()
         print("\nDaemon stopped.")
         _log_entry(log_dir, {"event": "daemon_stop", "reason": "keyboard_interrupt"})

--- a/src/agentinbox/keep_awake.py
+++ b/src/agentinbox/keep_awake.py
@@ -1,0 +1,43 @@
+"""Prevent the host from sleeping using the Win32 SetThreadExecutionState API.
+
+This works at the user level (no admin rights required) and does not require
+control over the host's power plan settings. The daemon calls prevent_sleep()
+on startup and allow_sleep() on shutdown.
+"""
+from __future__ import annotations
+
+import sys
+
+ES_CONTINUOUS = 0x80000000
+ES_SYSTEM_REQUIRED = 0x00000001
+
+_active = False
+
+
+def prevent_sleep() -> bool:
+    """Request the OS to stay awake. Returns True on success."""
+    global _active
+    if sys.platform != "win32":
+        return False
+    try:
+        import ctypes
+        result = ctypes.windll.kernel32.SetThreadExecutionState(
+            ES_CONTINUOUS | ES_SYSTEM_REQUIRED
+        )
+        _active = result != 0
+        return _active
+    except Exception:
+        return False
+
+
+def allow_sleep() -> None:
+    """Release the stay-awake request."""
+    global _active
+    if not _active or sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        ctypes.windll.kernel32.SetThreadExecutionState(ES_CONTINUOUS)
+        _active = False
+    except Exception:
+        pass


### PR DESCRIPTION
Add a keep_awake module that uses the Win32 SetThreadExecutionState API to prevent the host from sleeping while the daemon is running. This fixes an issue where the daemon became unresponsive for hours because the host entered sleep mode.

The prevent_sleep() call is made at daemon startup and released on shutdown. It works at the user level without admin rights or control over the host power plan settings. On non-Windows platforms it is a no-op.
